### PR TITLE
Select the first leading element for draft titles

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -118,7 +118,7 @@ async function gatherPostData(content, options, filePath) {
   else {
     // construct a canonical link
     var canonicalLink = $('footer > p > a').attr('href');
-    var blogTitle = $(".graf--leading").text()
+    var blogTitle = $(".graf--leading").first().text()
     var titleForSlug = convertToSlug(blogTitle)
   }
 


### PR DESCRIPTION
Some medium exported drafts have multiple elements with the `graf--leading` class.
When multiples exists the resulting `titleForSlug` can be potentially very long and cause the image fetching to fail due to too long file names.